### PR TITLE
Flatten json

### DIFF
--- a/models/model.js
+++ b/models/model.js
@@ -157,7 +157,7 @@ class BaseModel {
         return new Promise(function(resolve, reject) {
             self.DBModel.updateOne(query, body, function(err, data) {
                 if(err) {
-                    reject({"error" : true, "data" : data});  
+                    reject({"error" : true, "data" : data, "type" : err.name});  
                 } else {
                     resolve({"body" : body, "data" : data});
                 }

--- a/models/model.js
+++ b/models/model.js
@@ -160,7 +160,7 @@ class BaseModel {
             if(err) {
                 reject({"error" : true, "data": err});  
             } else {
-                resolve(body);
+                resolve(data);
             }
             self.closeConnection();
             });

--- a/models/model.js
+++ b/models/model.js
@@ -103,11 +103,10 @@ class BaseModel {
     async read(query) {
         var self = this;
         return new Promise(function(resolve, reject) {
-                var response = null;
                 self.init(); 
                 self.DBModel.find(query,function(err, data){
                 if(err) {
-                    reject({"error" : true,"message" : "Error fetching data", "errorMsg:" : err});  
+                    reject({"error" : true, "message" : "Error fetching data", "errorMsg:" : err});  
                 } else {
                     resolve(data);
                 }
@@ -157,12 +156,12 @@ class BaseModel {
         this.init();
         return new Promise(function(resolve, reject) {
             self.DBModel.updateOne(query, body, function(err, data) {
-            if(err) {
-                reject({"error" : true, "data": err});  
-            } else {
-                resolve(data);
-            }
-            self.closeConnection();
+                if(err) {
+                    reject({"error" : true, "data" : data});  
+                } else {
+                    resolve({"body" : body, "data" : data});
+                }
+                self.closeConnection();
             });
         });
 
@@ -175,7 +174,7 @@ class BaseModel {
         return new Promise(function(resolve, reject) {
             self.DBModel.findOneAndUpdate(id, body, function(err, data) {
                 if(err) {
-                    reject({"error" : 1, "data": err});  
+                    reject({"error" : true, "data": err});  
                 } else {
                     resolve(Object.assign({}, body));
                 }
@@ -197,9 +196,9 @@ class BaseModel {
                 } else {
                     self.DBModel.remove(query,function(err){
                         if(err) {
-                            reject({"error" : true,"message" : "Error deleting data", "errorMsg:" : err});  
+                            reject({"error" : true, "message" : "Error deleting data", "errorMsg:" : err});  
                         } else {
-                            resolve(Object.assign(query,{"error" : false,"message" : "Delete success."}));
+                            resolve(Object.assign(query,{"error" : false, "message" : "Delete success."}));
                         }
                         self.closeConnection();
                     });

--- a/models/model.js
+++ b/models/model.js
@@ -34,6 +34,19 @@ class BaseModel {
         return Object.assign({},data);
     };
 
+    JSONFlatten(json, current) {
+        for(var key in json) {
+            var value = json[key];
+            var newKey = (current ? current + "." + key : key);
+            if(value && value.constructor.name === "Object") {
+                this.JSONFlatten(value, newKey);
+            } else {
+                this.newJson[newKey] = value;
+            }
+        }
+        return this.newJson;
+    };
+
     createQuery(data) {
         var newObject = this.sanitizeData(data);
     
@@ -135,8 +148,12 @@ class BaseModel {
     }
 
     async update(query, body) {
-        body = this.sanitizeData(body);
         var self = this;
+        this.newJson = {};
+        
+        body = this.sanitizeData(body);
+        body = this.JSONFlatten({... body});
+        
         this.init();
         return new Promise(function(resolve, reject) {
             self.DBModel.updateOne(query, body, function(err, data) {


### PR DESCRIPTION
Add a new function that change how micronode updates an object in mongodb.

JSON-to-insert becomes from { a : { b : "c" }} to { a.b : "c" } . It prevents the erasing of data such as { a : { d : e }}.